### PR TITLE
fixed mismatch between string and bool

### DIFF
--- a/plugin/terminal_profiles.py
+++ b/plugin/terminal_profiles.py
@@ -49,7 +49,7 @@ class TerminalProfiles:
         return TerminalProfile(
             name = profile.get("name", ""),
             guid = profile.get("guid", ""),
-            hidden = profile.get("hidden", "false") != "false",
+            hidden = profile.get("hidden", False),
             terminal = terminal,
             info = info
         )


### PR DESCRIPTION
When testing around I found, that the hidden property of profile already is a bool rather than a string. This was tested with Python 3.10. Is this different for other Python versions / json  library versions?